### PR TITLE
Make CI to run on master 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,15 @@
 
 name: ci
 
-on: [ pull_request ]
-
+on:
+  push:
+    branches:
+    - master
+    - main 
+  pull_request:
+    branches:
+    - master
+    - main  
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is a small chance where we merge a duplicated link and just notice that in the main branch, mainly when different persons send the same link in different lines (I guess).  