### PR TITLE
Adiciona Portabilis

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A curated list of companies using php in production
 * [PetiKo](http://petiko.com.br/) | São Carlos, Brazil
 * [PicPay](https://www.picpay.com) | Vitória, Brazil; São Paulo, Brazil
 * [Pipe Run](https://secure.collage.co/jobs/piperuncrm) | Porto Alegre, Brazil
+* [Portabilis](https://portabilis.com.br/) | Içara, Brazil; Remote
 * [PrimeIt](https://www.primeit.pt/) | Lisboa, Portugal
 * [Rakuten](http://global.rakuten.com/en/) | Bamberg, Germany and Tokyo, Japan
 


### PR DESCRIPTION
Adiciona a [Portabilis](https://portabilis.com.br/) a lista de empresas que usam PHP em sua stack.

GitHub: http://github.com/portabilis