### PR TITLE
Set up PHP8 on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
       - name: Install dependencies
         run: composer install
       - name: Run PHPUnit


### PR DESCRIPTION
The vm used by the CI is using the latest version
of php which breaks the composer installation and
it might happen in the future as well. So it's a
good pratice to lock the version.